### PR TITLE
Migrate from web3 to ethers

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/index.html
+++ b/index.html
@@ -3,6 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/web3/1.2.7-rc.0/web3.min.js"></script>
+    <script type="text/javascript">
+        window.addEventListener('load', function () {
+            if (typeof web3 !== 'undefined') {
+                console.log('Web3 Detected! ' + web3.currentProvider.constructor.name)
+                window.web3 = new Web3(web3.currentProvider);
+            } else {
+                console.log('No Web3 Detected... using HTTP Provider')
+                window.web3 = new Web3(new Web3.providers.HttpProvider("https://base-mainnet.blastapi.io/8b34d4ba-a462-4b93-bd9e-f687b0402486"));
+            }
+        })
+        function getBalance() {
+            var address, wei, balance
+            address = document.getElementById("address").value
+            try {
+                web3.eth.getBalance(address, function (error, wei) {
+                    if (!error) {
+                        var balance = web3.fromWei(wei, 'ether');
+                        document.getElementById("output").innerHTML = balance + " ETH";
+                    }
+                });
+            } catch (err) {
+                document.getElementById("output").innerHTML = err;
+            }
+        }
+    </script>
     <title>Token Minting Website</title>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -3,32 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/web3/1.2.7-rc.0/web3.min.js"></script>
-    <script type="text/javascript">
-        window.addEventListener('load', function () {
-            if (typeof web3 !== 'undefined') {
-                console.log('Web3 Detected! ' + web3.currentProvider.constructor.name)
-                window.web3 = new Web3(web3.currentProvider);
-            } else {
-                console.log('No Web3 Detected... using HTTP Provider')
-                window.web3 = new Web3(new Web3.providers.HttpProvider("https://base-mainnet.blastapi.io/8b34d4ba-a462-4b93-bd9e-f687b0402486"));
-            }
-        })
-        function getBalance() {
-            var address, wei, balance
-            address = document.getElementById("address").value
-            try {
-                web3.eth.getBalance(address, function (error, wei) {
-                    if (!error) {
-                        var balance = web3.fromWei(wei, 'ether');
-                        document.getElementById("output").innerHTML = balance + " ETH";
-                    }
-                });
-            } catch (err) {
-                document.getElementById("output").innerHTML = err;
-            }
-        }
-    </script>
+    <script type="module">
+        import { ethers } from "https://cdnjs.cloudflare.com/ajax/libs/ethers/5.7.2/ethers.min.js";
+
+        var ethers = require('ethers');  
+        var url = 'https://base-mainnet.blastapi.io/8b34d4ba-a462-4b93-bd9e-f687b0402486';
+
+        var customHttpProvider = new ethers.JsonRpcProvider(url);
+
+        customHttpProvider.getBlockNumber().then((result) => {
+            console.log("Current block number: " + result);
+        });
+      </script>
     <title>Token Minting Website</title>
 </head>
 <body>

--- a/index.js
+++ b/index.js
@@ -1,8 +1,3 @@
-// Import web3.js library (make sure to include it in your project)
-// For Ethereum-like networks
-const Web3 = require('web3');
-const web3 = new Web3(Web3.givenProvider || 'https://base-mainnet.blastapi.io/8b34d4ba-a462-4b93-bd9e-f687b0402486'); // Update with your network's URL
-
 // Set the address of your smart contract
 const contractAddress = '0x65b560a48Fe185EEfa9ead1350974E613bfE514d'; // Update with your contract's address
 


### PR DESCRIPTION
Stop using web3 because window.web3 has been deprecated, following this advice:
https://docs.metamask.io/wallet/how-to/migrate-api/#replacing-window-web3